### PR TITLE
feat(logging): make log level configurable via RUST_LOG env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,10 +3951,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bigdecimal = "0.4.8"
 thiserror = "2.0.12"
 rust_decimal = "1.38.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 clap = { version = "4", features = ["derive"] }
 
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Settings can also be overridden via environment variables with the `PGE_` prefix
 PGE_LISTEN_ADDR=0.0.0.0:9090 ./pg_exporter run
 ```
 
+Log level is controlled via the standard `RUST_LOG` environment variable (default: `info`):
+
+```bash
+RUST_LOG=debug ./pg_exporter run                          # all debug output
+RUST_LOG=pg_exporter=debug,sqlx=warn ./pg_exporter run   # fine-grained control
+```
+
 ## CLI
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: .
     ports:
       - "127.0.0.1:61488:61488"
+    environment:
+      RUST_LOG: ${RUST_LOG:-info}
     depends_on:
       pge15:
         condition: service_healthy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use tracing::Level;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::FmtSubscriber;
 
 pub mod app;
@@ -9,14 +9,10 @@ pub mod instance;
 pub mod util;
 
 pub fn logger_init() {
-    // TODO: get debug flag from config or env and set log level.
-
-    // a builder for `FmtSubscriber`.
     let subscriber = FmtSubscriber::builder()
-        // all spans/events with a level higher than INFO (e.g, info, error, etc.)
-        // will be written to stdout.
-        .with_max_level(Level::INFO)
-        // completes the builder.
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");


### PR DESCRIPTION
Replace hardcoded INFO level with EnvFilter so operators can set RUST_LOG at runtime (e.g. RUST_LOG=debug or RUST_LOG=pg_exporter=debug,sqlx=warn). Falls back to info when RUST_LOG is not set.