### PR TITLE
Feat/per instance disable collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ instances:
     # collect_top_index: 10   # top-N indexes by usage
     # collect_top_table: 10   # top-N tables by size/activity
     # no_track_mode: true     # suppress query text in metrics (privacy mode)
+    # disable_collectors:     # skip specific collectors for this instance
+    #   - pg_statements       # e.g. no pg_stat_statements on replica
+    #   - pg_stat_io          # e.g. PG 15, not supported
     # pool_max_connections: 5 # override global default for this instance only
 ```
 
@@ -65,6 +68,7 @@ instances:
 | `instances.<name>.collect_top_index` | Top-N indexes by usage | `0` |
 | `instances.<name>.collect_top_table` | Top-N tables by size/activity | `0` |
 | `instances.<name>.no_track_mode` | Omit query text from metrics | `false` |
+| `instances.<name>.disable_collectors` | List of collector names to skip for this instance | `[]` |
 | `instances.<name>.pool_max_connections` | Max pool connections (overrides global) | `10` |
 | `instances.<name>.pool_acquire_timeout_secs` | Seconds to wait for a free connection (overrides global) | `5` |
 | `instances.<name>.pool_idle_timeout_secs` | Seconds before idle connection is closed (overrides global) | `300` |

--- a/README.md
+++ b/README.md
@@ -100,10 +100,37 @@ Options:
   -c, --config <PATH>   Path to config file [default: pg_exporter.yml]
 
 Commands:
-  run           Start the exporter
+  run               Start the exporter
     -l, --listen-addr <ADDR>   Override listen address from config
     -e, --endpoint <PATH>      Override metrics endpoint from config
-  configcheck   Validate the config file and exit with status 0 or 1
+  configcheck       Validate the config file and exit with status 0 or 1
+  list-collectors   Print all available collectors with their minimum PostgreSQL version
+```
+
+### list-collectors
+
+Use this command to discover collector names for use in `disable_collectors`:
+
+```
+$ pg_exporter list-collectors
+COLLECTOR                 MIN_PG_VERSION  NOTES
+pg_activity               9.5
+pg_archiver               9.5
+pg_bgwriter               9.5
+pg_conflict               9.5
+pg_database               9.5
+pg_indexes                9.5
+pg_locks                  9.5
+pg_postmaster             9.5
+pg_replication            9.6
+pg_replication_slots      9.6
+pg_settings               9.5
+pg_stat_io                16
+pg_stat_slru              13
+pg_statements             9.5             requires pg_stat_statements extension
+pg_storage                10
+pg_tables                 9.5
+pg_wal                    9.5
 ```
 
 ## Quick start with Docker Compose

--- a/pg_exporter.yml.dist
+++ b/pg_exporter.yml.dist
@@ -19,6 +19,9 @@ instances:
     collect_top_query: 10
     collect_top_index: 10
     no_track_mode: true
+    # disable_collectors:        # skip specific collectors for this instance
+    #   - pg_statements          # e.g. no pg_stat_statements on replica
+    #   - pg_stat_io             # e.g. PG 15, not supported
     # pool_max_connections: 5   # override global default for this instance
 
   "pg17:6432":

--- a/pg_exporter.yml.dist
+++ b/pg_exporter.yml.dist
@@ -20,8 +20,8 @@ instances:
     collect_top_index: 10
     no_track_mode: true
     # disable_collectors:        # skip specific collectors for this instance
-    #   - pg_statements          # e.g. no pg_stat_statements on replica
-    #   - pg_stat_io             # e.g. PG 15, not supported
+    #   - pg_statements          # run 'pg_exporter list-collectors' to see all names and min PG versions
+    #   - pg_stat_io
     # pool_max_connections: 5   # override global default for this instance
 
   "pg17:6432":

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,4 +26,6 @@ pub enum Commands {
     },
     /// Check configuration file for errors.
     Configcheck,
+    /// List available collectors with their minimum PostgreSQL version.
+    ListCollectors,
 }

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -35,6 +35,26 @@ const POSTGRES_V18: i64 = 180000;
 // Minimal required version is 9.5
 pub const POSTGRES_VMIN_NUM: i64 = POSTGRES_V95;
 
+pub const COLLECTOR_NAMES: &[&str] = &[
+    "pg_activity",
+    "pg_archiver",
+    "pg_bgwriter",
+    "pg_conflict",
+    "pg_database",
+    "pg_indexes",
+    "pg_locks",
+    "pg_postmaster",
+    "pg_replication",
+    "pg_replication_slots",
+    "pg_settings",
+    "pg_stat_io",
+    "pg_stat_slru",
+    "pg_statements",
+    "pg_storage",
+    "pg_tables",
+    "pg_wal",
+];
+
 #[async_trait]
 pub trait PG: DynClone + Send + Sync {
     async fn update(&self) -> Result<(), anyhow::Error>;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -35,6 +35,32 @@ const POSTGRES_V18: i64 = 180000;
 // Minimal required version is 9.5
 pub const POSTGRES_VMIN_NUM: i64 = POSTGRES_V95;
 
+pub struct CollectorInfo {
+    pub name: &'static str,
+    pub min_pg_version: &'static str,
+    pub notes: &'static str,
+}
+
+pub const COLLECTOR_INFO: &[CollectorInfo] = &[
+    CollectorInfo { name: "pg_activity",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_archiver",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_bgwriter",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_conflict",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_database",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_indexes",           min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_locks",             min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_postmaster",        min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_replication",       min_pg_version: "9.6",  notes: "" },
+    CollectorInfo { name: "pg_replication_slots", min_pg_version: "9.6",  notes: "" },
+    CollectorInfo { name: "pg_settings",          min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_stat_io",           min_pg_version: "16",   notes: "" },
+    CollectorInfo { name: "pg_stat_slru",         min_pg_version: "13",   notes: "" },
+    CollectorInfo { name: "pg_statements",        min_pg_version: "9.5",  notes: "requires pg_stat_statements extension" },
+    CollectorInfo { name: "pg_storage",           min_pg_version: "10",   notes: "" },
+    CollectorInfo { name: "pg_tables",            min_pg_version: "9.5",  notes: "" },
+    CollectorInfo { name: "pg_wal",               min_pg_version: "9.5",  notes: "" },
+];
+
 pub const COLLECTOR_NAMES: &[&str] = &[
     "pg_activity",
     "pg_archiver",

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -42,23 +42,91 @@ pub struct CollectorInfo {
 }
 
 pub const COLLECTOR_INFO: &[CollectorInfo] = &[
-    CollectorInfo { name: "pg_activity",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_archiver",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_bgwriter",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_conflict",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_database",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_indexes",           min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_locks",             min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_postmaster",        min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_replication",       min_pg_version: "9.6",  notes: "" },
-    CollectorInfo { name: "pg_replication_slots", min_pg_version: "9.6",  notes: "" },
-    CollectorInfo { name: "pg_settings",          min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_stat_io",           min_pg_version: "16",   notes: "" },
-    CollectorInfo { name: "pg_stat_slru",         min_pg_version: "13",   notes: "" },
-    CollectorInfo { name: "pg_statements",        min_pg_version: "9.5",  notes: "requires pg_stat_statements extension" },
-    CollectorInfo { name: "pg_storage",           min_pg_version: "10",   notes: "" },
-    CollectorInfo { name: "pg_tables",            min_pg_version: "9.5",  notes: "" },
-    CollectorInfo { name: "pg_wal",               min_pg_version: "9.5",  notes: "" },
+    CollectorInfo {
+        name: "pg_activity",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_archiver",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_bgwriter",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_conflict",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_database",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_indexes",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_locks",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_postmaster",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_replication",
+        min_pg_version: "9.6",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_replication_slots",
+        min_pg_version: "9.6",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_settings",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_stat_io",
+        min_pg_version: "16",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_stat_slru",
+        min_pg_version: "13",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_statements",
+        min_pg_version: "9.5",
+        notes: "requires pg_stat_statements extension",
+    },
+    CollectorInfo {
+        name: "pg_storage",
+        min_pg_version: "10",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_tables",
+        min_pg_version: "9.5",
+        notes: "",
+    },
+    CollectorInfo {
+        name: "pg_wal",
+        min_pg_version: "9.5",
+        notes: "",
+    },
 ];
 
 pub const COLLECTOR_NAMES: &[&str] = &[

--- a/src/config.rs
+++ b/src/config.rs
@@ -478,4 +478,69 @@ instances:
             .dsn = "postgresql://u:p@localhost/db".to_string();
         assert!(cfg.validate().is_ok());
     }
+
+    #[test]
+    fn validate_disable_collectors_known_names_ok() {
+        let mut cfg = valid_cfg();
+        cfg.instances
+            .as_mut()
+            .unwrap()
+            .get_mut("pg:5432")
+            .unwrap()
+            .disable_collectors = Some(vec![
+            "pg_statements".to_string(),
+            "pg_stat_io".to_string(),
+        ]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_disable_collectors_unknown_name_err() {
+        let mut cfg = valid_cfg();
+        cfg.instances
+            .as_mut()
+            .unwrap()
+            .get_mut("pg:5432")
+            .unwrap()
+            .disable_collectors = Some(vec!["pg_typo".to_string()]);
+        let err = cfg.validate().unwrap_err();
+        assert!(err.to_string().contains("unknown collector 'pg_typo'"));
+    }
+
+    #[test]
+    fn validate_disable_collectors_empty_list_ok() {
+        let mut cfg = valid_cfg();
+        cfg.instances
+            .as_mut()
+            .unwrap()
+            .get_mut("pg:5432")
+            .unwrap()
+            .disable_collectors = Some(vec![]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn load_config_with_disable_collectors() {
+        let yaml = r#"
+listen_addr: "0.0.0.0:9090"
+endpoint: /metrics
+instances:
+  "pg:5432":
+    dsn: "postgres://u:p@localhost/db"
+    const_labels: {}
+    disable_collectors:
+      - pg_statements
+      - pg_stat_io
+"#;
+        let path = write_tmp_config("pge_test_disable_collectors.yml", yaml);
+        let ec = ExporterConfig::load(&path).expect("should load");
+
+        let instances = ec.config.instances.expect("instances should be present");
+        let inst = instances.get("pg:5432").expect("instance should exist");
+        let disabled = inst
+            .disable_collectors
+            .as_ref()
+            .expect("disable_collectors should be present");
+        assert_eq!(disabled, &["pg_statements", "pg_stat_io"]);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,16 @@ impl PGEConfig {
                     inst.dsn
                 );
             }
+            if let Some(disabled) = &inst.disable_collectors {
+                for col in disabled {
+                    if !crate::collectors::COLLECTOR_NAMES.contains(&col.as_str()) {
+                        bail!(
+                            "config: instance '{name}': unknown collector '{col}' in disable_collectors (known: {})",
+                            crate::collectors::COLLECTOR_NAMES.join(", ")
+                        );
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -487,10 +487,7 @@ instances:
             .unwrap()
             .get_mut("pg:5432")
             .unwrap()
-            .disable_collectors = Some(vec![
-            "pg_statements".to_string(),
-            "pg_stat_io".to_string(),
-        ]);
+            .disable_collectors = Some(vec!["pg_statements".to_string(), "pg_stat_io".to_string()]);
         assert!(cfg.validate().is_ok());
     }
 

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -51,6 +51,7 @@ pub struct Config {
     pub pool_acquire_timeout_secs: Option<u64>,
     pub pool_idle_timeout_secs: Option<u64>,
     pub pool_max_lifetime_secs: Option<u64>,
+    pub disable_collectors: Option<Vec<String>>,
 }
 
 pub async fn new(instance_cfg: &Config) -> anyhow::Result<PostgresDB> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> std::io::Result<()> {
 
     match args.command {
         Some(Commands::ListCollectors) => {
-            println!("{:<25} {:<15} {}", "COLLECTOR", "MIN_PG_VERSION", "NOTES");
+            println!("{:<25} {:<15} NOTES", "COLLECTOR", "MIN_PG_VERSION");
             for info in collectors::COLLECTOR_INFO {
                 println!(
                     "{:<25} {:<15} {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,10 @@ async fn main() -> std::io::Result<()> {
         Some(Commands::ListCollectors) => {
             println!("{:<25} {:<15} {}", "COLLECTOR", "MIN_PG_VERSION", "NOTES");
             for info in collectors::COLLECTOR_INFO {
-                println!("{:<25} {:<15} {}", info.name, info.min_pg_version, info.notes);
+                println!(
+                    "{:<25} {:<15} {}",
+                    info.name, info.min_pg_version, info.notes
+                );
             }
             exit(0);
         }
@@ -271,7 +274,10 @@ async fn pgexporter(command: Option<Commands>, mut ec: ExporterConfig) -> anyhow
                 reg!("pg_tables", collectors::pg_tables::new);
                 reg!("pg_storage", collectors::pg_storage::new);
                 reg!("pg_replication", collectors::pg_replication::new);
-                reg!("pg_replication_slots", collectors::pg_replication_slots::new);
+                reg!(
+                    "pg_replication_slots",
+                    collectors::pg_replication_slots::new
+                );
                 reg!("pg_settings", collectors::pg_settings::new);
 
                 app.instances.push(arc_pgi);

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,14 @@ async fn pgexporter(command: Option<Commands>, mut ec: ExporterConfig) -> anyhow
             for (instance, config) in ec.config.instances.take().unwrap_or_default() {
                 info!("starting connection for instance: {instance}");
 
+                let disabled: std::collections::HashSet<String> = config
+                    .disable_collectors
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .cloned()
+                    .collect();
+
                 let pgi = match instance::new(&ec.config.merge_pool_defaults(config)).await {
                     Ok(p) => p,
                     Err(e) => {
@@ -232,108 +240,31 @@ async fn pgexporter(command: Option<Commands>, mut ec: ExporterConfig) -> anyhow
                 pgi.name = instance.clone();
                 let arc_pgi = Arc::new(pgi);
 
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_locks",
-                    collectors::pg_locks::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_postmaster",
-                    collectors::pg_postmaster::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_database",
-                    collectors::pg_database::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_activity",
-                    collectors::pg_activity::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_bgwriter",
-                    collectors::pg_bgwriter::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_wal",
-                    collectors::pg_wal::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_stat_io",
-                    collectors::pg_stat_io::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_stat_slru",
-                    collectors::pg_stat_slru::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_archiver",
-                    collectors::pg_archiver::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_conflict",
-                    collectors::pg_conflict::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_indexes",
-                    collectors::pg_indexes::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_statements",
-                    collectors::pg_statements::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_tables",
-                    collectors::pg_tables::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_storage",
-                    collectors::pg_storage::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_replication",
-                    collectors::pg_replication::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_replication_slots",
-                    collectors::pg_replication_slots::new,
-                )?;
-                register_collector(
-                    &mut app,
-                    Arc::clone(&arc_pgi),
-                    "pg_settings",
-                    collectors::pg_settings::new,
-                )?;
+                macro_rules! reg {
+                    ($name:literal, $new_fn:expr) => {
+                        if !disabled.contains($name) {
+                            register_collector(&mut app, Arc::clone(&arc_pgi), $name, $new_fn)?;
+                        }
+                    };
+                }
+
+                reg!("pg_locks", collectors::pg_locks::new);
+                reg!("pg_postmaster", collectors::pg_postmaster::new);
+                reg!("pg_database", collectors::pg_database::new);
+                reg!("pg_activity", collectors::pg_activity::new);
+                reg!("pg_bgwriter", collectors::pg_bgwriter::new);
+                reg!("pg_wal", collectors::pg_wal::new);
+                reg!("pg_stat_io", collectors::pg_stat_io::new);
+                reg!("pg_stat_slru", collectors::pg_stat_slru::new);
+                reg!("pg_archiver", collectors::pg_archiver::new);
+                reg!("pg_conflict", collectors::pg_conflict::new);
+                reg!("pg_indexes", collectors::pg_indexes::new);
+                reg!("pg_statements", collectors::pg_statements::new);
+                reg!("pg_tables", collectors::pg_tables::new);
+                reg!("pg_storage", collectors::pg_storage::new);
+                reg!("pg_replication", collectors::pg_replication::new);
+                reg!("pg_replication_slots", collectors::pg_replication_slots::new);
+                reg!("pg_settings", collectors::pg_settings::new);
 
                 app.instances.push(arc_pgi);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,14 @@ async fn main() -> std::io::Result<()> {
     let mut overrides = Overrides::default();
 
     match args.command {
+        Some(Commands::ListCollectors) => {
+            println!("{:<25} {:<15} {}", "COLLECTOR", "MIN_PG_VERSION", "NOTES");
+            for info in collectors::COLLECTOR_INFO {
+                println!("{:<25} {:<15} {}", info.name, info.min_pg_version, info.notes);
+            }
+            exit(0);
+        }
+
         Some(Commands::Configcheck) => {
             let ec = match ExporterConfig::load(Path::new(&args.config)) {
                 Ok(ec) => ec,


### PR DESCRIPTION
## Summary

- Add `disable_collectors` field to instance config — allows skipping specific
  collectors per instance without affecting others
- Validation in `configcheck` rejects unknown collector names with a clear error
- Add `list-collectors` command that prints all 17 collectors with minimum
  PostgreSQL version and notes (e.g. required extensions)

## Motivation

Not all collectors are applicable to every instance:
- replicas don't have `pg_stat_statements`
- `pg_stat_io` requires PG 16+
- some setups want to reduce metric cardinality

Previously all 17 collectors were unconditionally registered per instance.

## Usage

```yaml
instances:
  "pg-replica:5432":
    dsn: "..."
    disable_collectors:
      - pg_statements
      - pg_stat_io
```

```
$ pg_exporter list-collectors
COLLECTOR                 MIN_PG_VERSION  NOTES
pg_stat_io                16
pg_stat_slru              13
pg_statements             9.5             requires pg_stat_statements extension
...