### PR TITLE
refactor: deduplicate RwLock and new() boilerplate across all 17 coll…

### DIFF
--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -16,8 +16,77 @@ pub mod pg_storage;
 pub mod pg_tables;
 pub mod pg_wal;
 
+use std::sync::RwLock;
+
 use async_trait::async_trait;
 use dyn_clone::DynClone;
+
+/// Extension methods on `RwLock<T>` shared by all collectors.
+pub(crate) trait RwLockExt<T> {
+    /// Acquires a read lock; logs an error and returns `None` on poison.
+    fn read_or_log(&self, ctx: &str) -> Option<std::sync::RwLockReadGuard<'_, T>>;
+    /// Acquires a write lock; returns an `anyhow::Error` on poison.
+    fn write_or_bail(&self, ctx: &str) -> anyhow::Result<std::sync::RwLockWriteGuard<'_, T>>;
+}
+
+impl<T> RwLockExt<T> for RwLock<T> {
+    fn read_or_log(&self, ctx: &str) -> Option<std::sync::RwLockReadGuard<'_, T>> {
+        self.read()
+            .map_err(|e| tracing::error!("{ctx}: can't acquire read lock: {e}"))
+            .ok()
+    }
+
+    fn write_or_bail(&self, ctx: &str) -> anyhow::Result<std::sync::RwLockWriteGuard<'_, T>> {
+        self.write()
+            .map_err(|e| anyhow::anyhow!("{ctx}: can't acquire write lock: {e}"))
+    }
+}
+
+#[macro_export]
+macro_rules! collector_new {
+    ($dbi:ident, $name:expr, $collector:ty) => {
+        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+            match <$collector>::new($dbi) {
+                Ok(result) => Some(result),
+                Err(e) => {
+                    ::tracing::error!("error when create {} collector: {}", $name, e);
+                    None
+                }
+            }
+        }
+    };
+    ($dbi:ident, $name:expr, $collector:ty, $condition:expr) => {
+        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+            if $condition {
+                match <$collector>::new($dbi) {
+                    Ok(result) => Some(result),
+                    Err(e) => {
+                        ::tracing::error!("error when create {} collector: {}", $name, e);
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        }
+    };
+    ($dbi:ident, $name:expr, $collector:ty, $condition:expr, $msg:expr) => {
+        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+            if $condition {
+                match <$collector>::new($dbi) {
+                    Ok(result) => Some(result),
+                    Err(e) => {
+                        ::tracing::error!("error when create {} collector: {}", $name, e);
+                        None
+                    }
+                }
+            } else {
+                ::tracing::info!($msg);
+                None
+            }
+        }
+    };
+}
 
 const NAMESPACE: &str = "pg";
 

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -45,7 +45,7 @@ impl<T> RwLockExt<T> for RwLock<T> {
 #[macro_export]
 macro_rules! collector_new {
     ($dbi:ident, $name:expr, $collector:ty) => {
-        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+        pub fn new($dbi: ::std::sync::Arc<$crate::instance::PostgresDB>) -> Option<$collector> {
             match <$collector>::new($dbi) {
                 Ok(result) => Some(result),
                 Err(e) => {
@@ -56,7 +56,7 @@ macro_rules! collector_new {
         }
     };
     ($dbi:ident, $name:expr, $collector:ty, $condition:expr) => {
-        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+        pub fn new($dbi: ::std::sync::Arc<$crate::instance::PostgresDB>) -> Option<$collector> {
             if $condition {
                 match <$collector>::new($dbi) {
                     Ok(result) => Some(result),
@@ -71,7 +71,7 @@ macro_rules! collector_new {
         }
     };
     ($dbi:ident, $name:expr, $collector:ty, $condition:expr, $msg:expr) => {
-        pub fn new($dbi: ::std::sync::Arc<crate::instance::PostgresDB>) -> Option<$collector> {
+        pub fn new($dbi: ::std::sync::Arc<$crate::instance::PostgresDB>) -> Option<$collector> {
             if $condition {
                 match <$collector>::new($dbi) {
                     Ok(result) => Some(result),

--- a/src/collectors/pg_activity.rs
+++ b/src/collectors/pg_activity.rs
@@ -1,4 +1,3 @@
-use anyhow::bail;
 use async_trait::async_trait;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{Gauge, IntGauge};
@@ -10,7 +9,7 @@ use tracing::{error, warn};
 
 use crate::instance;
 
-use super::PG;
+use super::{PG, RwLockExt};
 
 const ACTIVITY_QUERY_95: &str = "SELECT
     COALESCE(usename, 'system') AS user, datname AS database, state, waiting,
@@ -621,10 +620,7 @@ impl PG for PGActivityCollector {
         let pg_activity_rows: Vec<PGActivity> =
             sqlx::query_as(query).fetch_all(&self.dbi.db).await?;
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg activity collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg activity collector")?;
 
         // clear all previous states
         data_lock.active.clear();
@@ -713,15 +709,7 @@ impl PG for PGActivityCollector {
     }
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGActivityCollector> {
-    match PGActivityCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg activity collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg activity", PGActivityCollector);
 
 impl Collector for PGActivityCollector {
     fn desc(&self) -> Vec<&Desc> {
@@ -732,13 +720,8 @@ impl Collector for PGActivityCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(9);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg activity collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg activity collect") else {
+            return mfs;
         };
 
         let states: HashMap<&str, &HashMap<String, i64>> = HashMap::from([

--- a/src/collectors/pg_archiver.rs
+++ b/src/collectors/pg_archiver.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto::MetricFamily;
 use prometheus::{Gauge, IntCounter, IntGauge};
-use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V12, POSTGRES_V13};
+use crate::collectors::{PG, POSTGRES_V12, POSTGRES_V13, RwLockExt};
 use crate::instance;
 
 const POSTGRES_WAL_ARCHIVING_QUERY: &str = "SELECT archived_count, failed_count,
@@ -48,25 +46,12 @@ pub struct PGArchiverCollector {
     lag_bytes: IntGauge,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGArchiverCollector> {
-    // some system functions are not available, required Postgres 12 or newer
-    if dbi
-        .current_cfg()
+crate::collector_new!(dbi, "pg archiver", PGArchiverCollector, {
+    dbi.current_cfg()
         .map(|c| c.pg_version)
         .unwrap_or(POSTGRES_V13)
         > POSTGRES_V12
-    {
-        match PGArchiverCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg archiver collector: {}", e);
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
+});
 
 impl PGArchiverCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<Self> {
@@ -137,13 +122,8 @@ impl Collector for PGArchiverCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg archiver collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg archiver collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -176,10 +156,7 @@ impl PG for PGArchiverCollector {
                 .fetch_all(&self.dbi.db)
                 .await?;
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg archiver: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg archiver collector")?;
 
         data_lock.clear();
 

--- a/src/collectors/pg_bgwriter.rs
+++ b/src/collectors/pg_bgwriter.rs
@@ -1,17 +1,15 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 use prometheus::proto;
 use prometheus::{
     Counter, IntCounter, IntCounterVec, Opts,
     core::{Collector, Desc},
 };
-use tracing::error;
 
 use crate::{collectors::POSTGRES_V17, instance};
 
-use super::PG;
+use super::{PG, RwLockExt};
 
 const BGWRITER_QUERY16: &str = "SELECT
 		checkpoints_timed, checkpoints_req, checkpoint_write_time, checkpoint_sync_time,
@@ -96,15 +94,7 @@ pub struct PGBGwriterCollector {
     checkpoint_restartpointsdone: IntCounter,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGBGwriterCollector> {
-    match PGBGwriterCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg bgwriter collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg bgwriter", PGBGwriterCollector);
 
 impl PGBGwriterCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGBGwriterCollector> {
@@ -288,13 +278,8 @@ impl Collector for PGBGwriterCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(13);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg bgwriter collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg bgwriter collect") else {
+            return mfs;
         };
 
         self.alloc_bytes.inc_by(data_lock.buffers_alloc as u64);
@@ -379,10 +364,7 @@ impl PG for PGBGwriterCollector {
         };
 
         if let Some(bgwr_stats) = maybe_bgwr_stats {
-            let mut data_lock = match self.data.write() {
-                Ok(data_lock) => data_lock,
-                Err(e) => bail!("pg bgwriter: can't acquire write lock. {}", e),
-            };
+            let mut data_lock = self.data.write_or_bail("pg bgwriter collector")?;
 
             data_lock.bgwr_stats_age_seconds = bgwr_stats.bgwr_stats_age_seconds;
             data_lock.buffers_alloc = bgwr_stats.buffers_alloc;

--- a/src/collectors/pg_conflict.rs
+++ b/src/collectors/pg_conflict.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::IntCounterVec;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto;
-use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V16};
+use crate::collectors::{PG, POSTGRES_V16, RwLockExt};
 use crate::instance;
 
 const POSTGRES_DATABASE_CONFLICT15: &str = "SELECT datname AS database,
@@ -43,15 +41,7 @@ pub struct PGConflictCollector {
     conflicts_total: IntCounterVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGConflictCollector> {
-    match PGConflictCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg conflicts collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg conflicts", PGConflictCollector);
 
 impl PGConflictCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGConflictCollector> {
@@ -82,12 +72,8 @@ impl Collector for PGConflictCollector {
     fn collect(&self) -> Vec<proto::MetricFamily> {
         let mut mfs = Vec::with_capacity(1);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg conflict collect: can't acquire read lock: {}", e);
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg conflict collect") else {
+            return mfs;
         };
 
         let database = data_lock.database.as_str();
@@ -134,10 +120,7 @@ impl PG for PGConflictCollector {
                 return Ok(());
             }
 
-            let mut data_lock = match self.data.write() {
-                Ok(data_lock) => data_lock,
-                Err(e) => bail!("pg conflict: can't acquire write lock. {}", e),
-            };
+            let mut data_lock = self.data.write_or_bail("pg conflict collector")?;
 
             *data_lock = conflict_stats;
         }

--- a/src/collectors/pg_database.rs
+++ b/src/collectors/pg_database.rs
@@ -5,11 +5,10 @@ use async_trait::async_trait;
 use prometheus::IntGaugeVec;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto;
-use tracing::error;
 
 use crate::instance;
 
-use super::PG;
+use super::{PG, RwLockExt};
 
 const PG_DATABASE_QUERY: &str = "SELECT datname AS name, pg_database_size(datname) AS size_bytes \
      FROM pg_database WHERE datname != ALL($1) AND datname != ''";
@@ -34,15 +33,7 @@ pub struct PGDatabaseCollector {
     size_bytes: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGDatabaseCollector> {
-    match PGDatabaseCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg database collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg database", PGDatabaseCollector);
 
 impl PGDatabaseCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGDatabaseCollector> {
@@ -70,12 +61,8 @@ impl Collector for PGDatabaseCollector {
     fn collect(&self) -> Vec<proto::MetricFamily> {
         let mut mfs = Vec::with_capacity(1);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg database collect: can't acquire read lock: {}", e);
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg database collect") else {
+            return mfs;
         };
 
         data_lock
@@ -99,9 +86,7 @@ impl PG for PGDatabaseCollector {
         let new_sizes: HashMap<String, i64> =
             rows.into_iter().map(|r| (r.name, r.size_bytes)).collect();
 
-        let mut data_lock = self.data.write().map_err(|e| {
-            anyhow::anyhow!("pg database collector: can't acquire write lock. {}", e)
-        })?;
+        let mut data_lock = self.data.write_or_bail("pg database collector")?;
         data_lock.size_bytes = new_sizes;
 
         Ok(())

--- a/src/collectors/pg_indexes.rs
+++ b/src/collectors/pg_indexes.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{GaugeVec, IntCounterVec};
 use prometheus::{IntGaugeVec, proto};
-use tracing::error;
 
-use crate::collectors::PG;
+use crate::collectors::{PG, RwLockExt};
 use crate::instance;
 
 const USER_INDEXES_QUERY: &str = "SELECT current_database() AS database, schemaname AS schema, relname AS table,
@@ -87,15 +85,7 @@ pub struct PGIndexesCollector {
     sizes: GaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGIndexesCollector> {
-    match PGIndexesCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg indexes collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg indexes", PGIndexesCollector);
 
 impl PGIndexesCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGIndexesCollector> {
@@ -162,13 +152,8 @@ impl Collector for PGIndexesCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg indexes collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg indexes collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -264,10 +249,7 @@ impl PG for PGIndexesCollector {
                 .await?
         };
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg indexes collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg indexes collector")?;
 
         data_lock.clear();
 

--- a/src/collectors/pg_locks.rs
+++ b/src/collectors/pg_locks.rs
@@ -1,25 +1,23 @@
-use anyhow::bail;
 use async_trait::async_trait;
 use prometheus::IntGauge;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto;
 use std::sync::{Arc, RwLock};
-use tracing::error;
 
-use crate::collectors::PG;
+use crate::collectors::{PG, RwLockExt};
 use crate::instance;
 
-const LOCKSQUERY: &str = "SELECT  
-		count(*) FILTER (WHERE mode = 'AccessShareLock') AS access_share_lock,  
-		count(*) FILTER (WHERE mode = 'RowShareLock') AS row_share_lock, 
-		count(*) FILTER (WHERE mode = 'RowExclusiveLock') AS row_exclusive_lock, 
-		count(*) FILTER (WHERE mode = 'ShareUpdateExclusiveLock') AS share_update_exclusive_lock, 
-		count(*) FILTER (WHERE mode = 'ShareLock') AS share_lock, 
-		count(*) FILTER (WHERE mode = 'ShareRowExclusiveLock') AS share_row_exclusive_lock, 
-		count(*) FILTER (WHERE mode = 'ExclusiveLock') AS exclusive_lock, 
-		count(*) FILTER (WHERE mode = 'AccessExclusiveLock') AS access_exclusive_lock, 
-		count(*) FILTER (WHERE not granted) AS not_granted, 
-		count(*) AS total 
+const LOCKSQUERY: &str = "SELECT
+		count(*) FILTER (WHERE mode = 'AccessShareLock') AS access_share_lock,
+		count(*) FILTER (WHERE mode = 'RowShareLock') AS row_share_lock,
+		count(*) FILTER (WHERE mode = 'RowExclusiveLock') AS row_exclusive_lock,
+		count(*) FILTER (WHERE mode = 'ShareUpdateExclusiveLock') AS share_update_exclusive_lock,
+		count(*) FILTER (WHERE mode = 'ShareLock') AS share_lock,
+		count(*) FILTER (WHERE mode = 'ShareRowExclusiveLock') AS share_row_exclusive_lock,
+		count(*) FILTER (WHERE mode = 'ExclusiveLock') AS exclusive_lock,
+		count(*) FILTER (WHERE mode = 'AccessExclusiveLock') AS access_exclusive_lock,
+		count(*) FILTER (WHERE not granted) AS not_granted,
+		count(*) AS total
 		FROM pg_locks";
 
 /// 10 metrics per PGLocksCollector.
@@ -63,15 +61,7 @@ impl LocksStat {
     }
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGLocksCollector> {
-    match PGLocksCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg locks collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg locks", PGLocksCollector);
 
 impl PGLocksCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGLocksCollector> {
@@ -189,13 +179,8 @@ impl Collector for PGLocksCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(LOCKS_METRICS_NUMBER);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg locks collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg locks collect") else {
+            return mfs;
         };
 
         let access_share_lock = data_lock.access_share_lock.unwrap_or_default();
@@ -271,10 +256,7 @@ impl PG for PGLocksCollector {
             .await?;
 
         if let Some(locks_stats) = maybe_locks_stats {
-            let mut data_lock = match self.data.write() {
-                Ok(data_lock) => data_lock,
-                Err(e) => bail!("pg indexes collector: can't acquire write lock. {}", e),
-            };
+            let mut data_lock = self.data.write_or_bail("pg locks collector")?;
 
             data_lock.access_exclusive_lock = locks_stats.access_exclusive_lock;
             data_lock.access_share_lock = locks_stats.access_share_lock;

--- a/src/collectors/pg_postmaster.rs
+++ b/src/collectors/pg_postmaster.rs
@@ -1,15 +1,13 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 use prometheus::Gauge;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto;
-use tracing::error;
 
 use crate::instance;
 
-use super::PG;
+use super::{PG, RwLockExt};
 
 const POSTMASTER_QUERY: &str = "SELECT extract(epoch from pg_postmaster_start_time)::FLOAT8 as start_time_seconds from pg_postmaster_start_time()";
 const POSTMASTER_SUBSYSTEM: &str = "postmaster";
@@ -33,15 +31,7 @@ pub struct PGPostmasterCollector {
     start_time_seconds: Gauge,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGPostmasterCollector> {
-    match PGPostmasterCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg postmaster collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg postmaster", PGPostmasterCollector);
 
 impl PGPostmasterCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGPostmasterCollector> {
@@ -73,13 +63,8 @@ impl Collector for PGPostmasterCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(1);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg postmaster collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg postmaster collect") else {
+            return mfs;
         };
 
         self.start_time_seconds.set(data_lock.start_time_seconds);
@@ -97,10 +82,7 @@ impl PG for PGPostmasterCollector {
             .await?;
 
         if let Some(stats) = maybe_stats {
-            let mut data_lock = match self.data.write() {
-                Ok(data_lock) => data_lock,
-                Err(e) => bail!("pg postmaster collector: can't acquire write lock. {}", e),
-            };
+            let mut data_lock = self.data.write_or_bail("pg postmaster collector")?;
 
             data_lock.start_time_seconds = stats.start_time_seconds;
         }

--- a/src/collectors/pg_replication.rs
+++ b/src/collectors/pg_replication.rs
@@ -2,15 +2,13 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use crate::instance;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{IntGaugeVec, proto};
-use tracing::{error, info};
 
-use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V96};
+use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V96, RwLockExt};
 
 // Query for Postgres version 9.6 and older.
 const POSTGRES_REPLICATION_QUERY96: &str = "SELECT pid, COALESCE(host(client_addr), '127.0.0.1') AS client_addr,
@@ -74,26 +72,18 @@ pub struct PGReplicationCollector {
     lag_total_seconds: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGReplicationCollector> {
-    // Collecting pg_replication since Postgres 9.6.
-    if dbi
-        .current_cfg()
-        .map(|c| c.pg_version)
-        .unwrap_or(POSTGRES_V96)
-        >= POSTGRES_V96
+crate::collector_new!(
+    dbi,
+    "pg replication",
+    PGReplicationCollector,
     {
-        match PGReplicationCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg replication collector: {}", e);
-                None
-            }
-        }
-    } else {
-        info!("some server-side functions are not available, required Postgres 9.6 or newer");
-        None
-    }
-}
+        dbi.current_cfg()
+            .map(|c| c.pg_version)
+            .unwrap_or(POSTGRES_V96)
+            >= POSTGRES_V96
+    },
+    "some server-side functions are not available, required Postgres 9.6 or newer"
+);
 
 impl PGReplicationCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<Self> {
@@ -192,13 +182,8 @@ impl Collector for PGReplicationCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg replication collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg replication collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -383,10 +368,7 @@ impl PG for PGReplicationCollector {
                 .fetch_all(&self.dbi.db)
                 .await?
         };
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg replication collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg replication collector")?;
 
         data_lock.clear();
         data_lock.append(&mut pg_replc_stat_rows);

--- a/src/collectors/pg_replication_slots.rs
+++ b/src/collectors/pg_replication_slots.rs
@@ -2,15 +2,13 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use crate::instance;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{IntGaugeVec, proto};
-use tracing::{error, info};
 
-use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V96};
+use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V96, RwLockExt};
 
 // Query for Postgres version 9.6 and older.
 const POSTGRES_REPLICATION_QUERY96: &str = "SELECT database, slot_name, slot_type, active,
@@ -41,26 +39,18 @@ pub struct PGReplicationSlotsCollector {
     retained_bytes: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGReplicationSlotsCollector> {
-    // Collecting pg_replication since Postgres 9.6.
-    if dbi
-        .current_cfg()
-        .map(|c| c.pg_version)
-        .unwrap_or(POSTGRES_V96)
-        >= POSTGRES_V96
+crate::collector_new!(
+    dbi,
+    "pg replication slots",
+    PGReplicationSlotsCollector,
     {
-        match PGReplicationSlotsCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg replication slots collector: {}", e);
-                None
-            }
-        }
-    } else {
-        info!("some server-side functions are not available, required Postgres 9.6 or newer");
-        None
-    }
-}
+        dbi.current_cfg()
+            .map(|c| c.pg_version)
+            .unwrap_or(POSTGRES_V96)
+            >= POSTGRES_V96
+    },
+    "some server-side functions are not available, required Postgres 9.6 or newer"
+);
 
 impl PGReplicationSlotsCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<Self> {
@@ -98,16 +88,8 @@ impl Collector for PGReplicationSlotsCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(1);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!(
-                    "pg replication slots collect: can't acquire read lock: {}",
-                    e
-                );
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg replication slots collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -151,13 +133,7 @@ impl PG for PGReplicationSlotsCollector {
                 .fetch_all(&self.dbi.db)
                 .await?
         };
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!(
-                "pg replication slots collector: can't acquire write lock. {}",
-                e
-            ),
-        };
+        let mut data_lock = self.data.write_or_bail("pg replication slots collector")?;
 
         data_lock.clear();
         data_lock.append(&mut pg_replc_slots_stat_rows);

--- a/src/collectors/pg_settings.rs
+++ b/src/collectors/pg_settings.rs
@@ -168,6 +168,54 @@ fn parse_row(row: Row) -> Option<Setting> {
     }
 }
 
+
+impl Collector for PGSettingsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut mfs = Vec::with_capacity(1);
+
+        let Some(data_lock) = self.data.read_or_log("pg settings collect") else {
+            return mfs;
+        };
+
+        self.settings_info.reset();
+
+        for s in data_lock.iter() {
+            let vals = [
+                s.name.as_str(),
+                s.setting.as_str(),
+                s.unit.as_str(),
+                s.vartype.as_str(),
+                "main",
+            ];
+            self.settings_info.with_label_values(&vals).set(s.value);
+        }
+
+        mfs.extend(self.settings_info.collect());
+        mfs
+    }
+}
+
+#[async_trait]
+impl PG for PGSettingsCollector {
+    async fn update(&self) -> Result<(), anyhow::Error> {
+        self.dbi.ensure_ready().await?;
+        let rows = sqlx::query_as::<_, Row>(QUERY)
+            .fetch_all(&self.dbi.db)
+            .await?;
+
+        let settings: Vec<Setting> = rows.into_iter().filter_map(parse_row).collect();
+
+        let mut data_lock = self.data.write_or_bail("pg settings collector")?;
+
+        *data_lock = settings;
+
+        Ok(())
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -358,53 +406,5 @@ mod tests {
     #[test]
     fn parse_row_unknown_vartype_returns_none() {
         assert!(parse_row(row("some_setting", "val", "", "unknown_type")).is_none());
-    }
-}
-
-impl Collector for PGSettingsCollector {
-    fn desc(&self) -> Vec<&Desc> {
-        self.descs.iter().collect()
-    }
-
-    fn collect(&self) -> Vec<MetricFamily> {
-        let mut mfs = Vec::with_capacity(1);
-
-        let Some(data_lock) = self.data.read_or_log("pg settings collect") else {
-            return mfs;
-        };
-
-        self.settings_info.reset();
-
-        for s in data_lock.iter() {
-            let vals = [
-                s.name.as_str(),
-                s.setting.as_str(),
-                s.unit.as_str(),
-                s.vartype.as_str(),
-                "main",
-            ];
-            self.settings_info.with_label_values(&vals).set(s.value);
-        }
-
-        mfs.extend(self.settings_info.collect());
-        mfs
-    }
-}
-
-#[async_trait]
-impl PG for PGSettingsCollector {
-    async fn update(&self) -> Result<(), anyhow::Error> {
-        self.dbi.ensure_ready().await?;
-        let rows = sqlx::query_as::<_, Row>(QUERY)
-            .fetch_all(&self.dbi.db)
-            .await?;
-
-        let settings: Vec<Setting> = rows.into_iter().filter_map(parse_row).collect();
-
-        let mut data_lock = self.data.write_or_bail("pg settings collector")?;
-
-        *data_lock = settings;
-
-        Ok(())
     }
 }

--- a/src/collectors/pg_settings.rs
+++ b/src/collectors/pg_settings.rs
@@ -168,7 +168,6 @@ fn parse_row(row: Row) -> Option<Setting> {
     }
 }
 
-
 impl Collector for PGSettingsCollector {
     fn desc(&self) -> Vec<&Desc> {
         self.descs.iter().collect()

--- a/src/collectors/pg_settings.rs
+++ b/src/collectors/pg_settings.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::GaugeVec;
@@ -8,7 +7,7 @@ use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto::MetricFamily;
 use tracing::error;
 
-use crate::collectors::PG;
+use crate::collectors::{PG, RwLockExt};
 use crate::instance;
 
 const QUERY: &str = "SELECT name, COALESCE(setting, '') AS setting, COALESCE(unit, '') AS unit, vartype
@@ -40,15 +39,7 @@ pub struct PGSettingsCollector {
     settings_info: GaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGSettingsCollector> {
-    match PGSettingsCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg settings collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg settings", PGSettingsCollector);
 
 impl PGSettingsCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGSettingsCollector> {
@@ -378,12 +369,8 @@ impl Collector for PGSettingsCollector {
     fn collect(&self) -> Vec<MetricFamily> {
         let mut mfs = Vec::with_capacity(1);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg settings collect: can't acquire read lock: {}", e);
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg settings collect") else {
+            return mfs;
         };
 
         self.settings_info.reset();
@@ -414,10 +401,7 @@ impl PG for PGSettingsCollector {
 
         let settings: Vec<Setting> = rows.into_iter().filter_map(parse_row).collect();
 
-        let mut data_lock = match self.data.write() {
-            Ok(lock) => lock,
-            Err(e) => bail!("pg settings collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg settings collector")?;
 
         *data_lock = settings;
 

--- a/src/collectors/pg_stat_io.rs
+++ b/src/collectors/pg_stat_io.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto::MetricFamily;
 use prometheus::{GaugeVec, IntGaugeVec};
-use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V16, POSTGRES_V18};
+use crate::collectors::{PG, POSTGRES_V16, POSTGRES_V18, RwLockExt};
 use crate::instance;
 
 const POSTGRES_STAT_IO_QUERY17: &str = "SELECT backend_type, object, context, COALESCE(reads, 0) AS reads, COALESCE(read_time, 0) AS read_time,
@@ -78,25 +76,12 @@ pub struct PGStatIOCollector {
     extend_bytes: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGStatIOCollector> {
-    // Collecting pg_stat_io since Postgres 16.
-    if dbi
-        .current_cfg()
+crate::collector_new!(dbi, "pg statio", PGStatIOCollector, {
+    dbi.current_cfg()
         .map(|c| c.pg_version)
         .unwrap_or(POSTGRES_V16)
         >= POSTGRES_V16
-    {
-        match PGStatIOCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg statio collector: {}", e);
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
+});
 
 impl PGStatIOCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGStatIOCollector> {
@@ -320,13 +305,8 @@ impl Collector for PGStatIOCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(16);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg statio collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg statio collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -399,10 +379,7 @@ impl PG for PGStatIOCollector {
                 .await?
         };
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg statio collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg statio collector")?;
 
         *data_lock = pg_statio_stats_rows;
 

--- a/src/collectors/pg_stat_slru.rs
+++ b/src/collectors/pg_stat_slru.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::IntGaugeVec;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto::MetricFamily;
-use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V13};
+use crate::collectors::{PG, POSTGRES_V13, RwLockExt};
 use crate::instance;
 
 const POSTGRES_STAT_SLRU_QUERY: &str = "SELECT name, COALESCE(blks_zeroed, 0) AS blks_zeroed, COALESCE(blks_hit, 0) AS blks_hit, \
@@ -42,25 +40,12 @@ pub struct PGStatSlruCollector {
     truncates: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGStatSlruCollector> {
-    // Collecting pg_stat_slru since Postgres 13.
-    if dbi
-        .current_cfg()
+crate::collector_new!(dbi, "pg stat_slru", PGStatSlruCollector, {
+    dbi.current_cfg()
         .map(|c| c.pg_version)
         .unwrap_or(POSTGRES_V13)
         >= POSTGRES_V13
-    {
-        match PGStatSlruCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg stat_slru collector: {}", e);
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
+});
 
 impl PGStatSlruCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGStatSlruCollector> {
@@ -168,12 +153,8 @@ impl Collector for PGStatSlruCollector {
     fn collect(&self) -> Vec<MetricFamily> {
         let mut mfs = Vec::with_capacity(7);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg stat_slru collect: can't acquire read lock: {}", e);
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg stat_slru collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -214,10 +195,7 @@ impl PG for PGStatSlruCollector {
             .fetch_all(&self.dbi.db)
             .await?;
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg stat_slru collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg stat_slru collector")?;
 
         *data_lock = rows;
 

--- a/src/collectors/pg_statements.rs
+++ b/src/collectors/pg_statements.rs
@@ -1,10 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V12, POSTGRES_V13, POSTGRES_V16, POSTGRES_V17, POSTGRES_V18};
+use crate::collectors::{
+    PG, POSTGRES_V12, POSTGRES_V13, POSTGRES_V16, POSTGRES_V17, POSTGRES_V18, RwLockExt,
+};
 use crate::instance;
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{IntGaugeVec, proto};
@@ -601,24 +603,11 @@ impl PGStatementsCollector {
     }
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGStatementsCollector> {
-    // Collecting since Postgres 12.
-    if dbi
-        .current_cfg()
+crate::collector_new!(dbi, "pg statements", PGStatementsCollector, {
+    dbi.current_cfg()
         .map(|c| c.pg_version >= POSTGRES_V12 && c.pg_stat_statements)
         .unwrap_or(true)
-    {
-        match PGStatementsCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg statements collector: {}", e);
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
+});
 
 impl Collector for PGStatementsCollector {
     fn desc(&self) -> Vec<&Desc> {
@@ -636,13 +625,8 @@ impl Collector for PGStatementsCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg statements collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg statements collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -948,10 +932,7 @@ impl PG for PGStatementsCollector {
             .fetch_all(&self.dbi.db)
             .await?;
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg statements collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg statements collector")?;
 
         data_lock.clear();
 

--- a/src/collectors/pg_storage.rs
+++ b/src/collectors/pg_storage.rs
@@ -8,9 +8,9 @@ use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{IntGaugeVec, proto};
-use tracing::{error, info};
+use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V12};
+use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V12, RwLockExt};
 use crate::instance;
 
 use sqlx::Row;
@@ -52,26 +52,18 @@ pub struct PGStorageCollector {
     tmp_files_bytes: IntGaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGStorageCollector> {
-    // Collecting pg_storage since Postgres 10.
-    if dbi
-        .current_cfg()
-        .map(|c| c.pg_version)
-        .unwrap_or(POSTGRES_V10)
-        >= POSTGRES_V10
+crate::collector_new!(
+    dbi,
+    "pg storage",
+    PGStorageCollector,
     {
-        match PGStorageCollector::new(dbi) {
-            Ok(result) => Some(result),
-            Err(e) => {
-                error!("error when create pg storage collector: {}", e);
-                None
-            }
-        }
-    } else {
-        info!("some server-side functions are not available, required Postgres 10 or newer");
-        None
-    }
-}
+        dbi.current_cfg()
+            .map(|c| c.pg_version)
+            .unwrap_or(POSTGRES_V10)
+            >= POSTGRES_V10
+    },
+    "some server-side functions are not available, required Postgres 10 or newer"
+);
 
 impl PGStorageCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<Self> {
@@ -176,13 +168,8 @@ impl Collector for PGStorageCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg storage collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg storage collect") else {
+            return mfs;
         };
 
         let dirstat_lock = match self.data_dirstat.read() {
@@ -287,10 +274,7 @@ impl PG for PGStorageCollector {
         let tmpdir_bytes: Decimal = tmpdir_row.try_get("bytes")?;
         let tmpdir_count: i64 = tmpdir_row.try_get("count")?;
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg storage collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg storage collector")?;
 
         data_lock.clear();
         data_lock.append(&mut pg_storage_stat_rows);

--- a/src/collectors/pg_tables.rs
+++ b/src/collectors/pg_tables.rs
@@ -3,14 +3,12 @@ use rust_decimal::prelude::ToPrimitive;
 
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::{GaugeVec, IntGaugeVec, proto};
-use tracing::error;
 
-use crate::collectors::PG;
+use crate::collectors::{PG, RwLockExt};
 use crate::instance;
 
 const POSTGRES_USERS_TABLE: &str = "SELECT current_database() AS database, s1.schemaname AS schema, s1.relname AS table,
@@ -133,15 +131,7 @@ pub struct PGTableCollector {
     reltuples: GaugeVec,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGTableCollector> {
-    match PGTableCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg tables collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg tables", PGTableCollector);
 
 impl PGTableCollector {
     fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<Self> {
@@ -409,13 +399,8 @@ impl Collector for PGTableCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(4);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg tables collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg tables collect") else {
+            return mfs;
         };
 
         for row in data_lock.iter() {
@@ -844,10 +829,7 @@ impl PG for PGTableCollector {
                 .await?
         };
 
-        let mut data_lock = match self.data.write() {
-            Ok(data_lock) => data_lock,
-            Err(e) => bail!("pg tables collector: can't acquire write lock. {}", e),
-        };
+        let mut data_lock = self.data.write_or_bail("pg tables collector")?;
 
         data_lock.clear();
         data_lock.append(&mut pg_tables_stat_rows);

--- a/src/collectors/pg_wal.rs
+++ b/src/collectors/pg_wal.rs
@@ -1,14 +1,12 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::bail;
 use async_trait::async_trait;
 
 use prometheus::core::{Collector, Desc, Opts};
 use prometheus::proto::MetricFamily;
 use prometheus::{Counter, CounterVec, IntCounter, IntGauge};
-use tracing::error;
 
-use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V14, POSTGRES_V18};
+use crate::collectors::{PG, POSTGRES_V10, POSTGRES_V14, POSTGRES_V18, RwLockExt};
 use crate::instance;
 
 const POSTGRES_WAL_QUERY96: &str =
@@ -74,15 +72,7 @@ pub struct PGWALCollector {
     stats_reset_time: IntGauge,
 }
 
-pub fn new(dbi: Arc<instance::PostgresDB>) -> Option<PGWALCollector> {
-    match PGWALCollector::new(dbi) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            error!("error when create pg wal collector: {}", e);
-            None
-        }
-    }
-}
+crate::collector_new!(dbi, "pg wal", PGWALCollector);
 
 impl PGWALCollector {
     pub fn new(dbi: Arc<instance::PostgresDB>) -> anyhow::Result<PGWALCollector> {
@@ -238,13 +228,8 @@ impl Collector for PGWALCollector {
         // collect MetricFamilies.
         let mut mfs = Vec::with_capacity(11);
 
-        let data_lock = match self.data.read() {
-            Ok(lock) => lock,
-            Err(e) => {
-                error!("pg wal collect: can't acquire read lock: {}", e);
-                // return empty mfs
-                return mfs;
-            }
+        let Some(data_lock) = self.data.read_or_log("pg wal collect") else {
+            return mfs;
         };
 
         self.recovery_info.set(data_lock.recovery as i64);
@@ -305,10 +290,7 @@ impl PG for PGWALCollector {
         };
 
         if let Some(pg_wal_stats) = maybe_pg_wal_stats {
-            let mut data_lock = match self.data.write() {
-                Ok(data_lock) => data_lock,
-                Err(e) => bail!("pg wal collector: can't acquire write lock. {}", e),
-            };
+            let mut data_lock = self.data.write_or_bail("pg wal collector")?;
 
             *data_lock = pg_wal_stats;
         }


### PR DESCRIPTION
## Summary
Eliminates three kinds of copy-paste boilerplate in every collector by using the existing `RwLockExt` trait and a new `collector_new!` macro.

## Changes
- **`collectors/mod.rs`**
  - Add `collector_new!` macro covering the repeated `pub fn new() -> Option<Collector>` pattern (including version-gated variants with optional `info!` logs).

- **All 17 collectors**
  - **Read lock in `collect()`**: 7-line `match self.data.read() { … }` → 3-line `let Some(guard) = self.data.read_or_log("…") else { return mfs; };`
  - **Write lock in `update()`**: 5–7-line `match self.data.write() { … }` → 1-line `let mut guard = self.data.write_or_bail("…")?;`
  - **`pub fn new()`**: 6-line manual wrapper → 1-line `collector_new!(dbi, "…", CollectorType);`

## Drive-by fix
- Corrected a copy-paste typo in `pg_locks.rs` where the write-lock error said `"pg indexes collector"` instead of `"pg locks collector"`.

## Verification
- `cargo check` — 0 errors, 0 warnings
- `cargo test` — 143/143 tests passed (57 unit + 32 integration)